### PR TITLE
Fix warnings and a bug in tests to close TDengine client connections before stopping test container

### DIFF
--- a/pva.SuperV.Engine/Processing/FieldValueProcessing.cs
+++ b/pva.SuperV.Engine/Processing/FieldValueProcessing.cs
@@ -12,7 +12,7 @@
         /// <value>
         /// The name.
         /// </value>
-        public string Name { get; set; }
+        public string Name { get; set; } = String.Empty;
 
         /// <summary>
         /// Gets or sets the constructor arguments.

--- a/pva.SuperV.EngineTests/TDengineTests.cs
+++ b/pva.SuperV.EngineTests/TDengineTests.cs
@@ -115,10 +115,10 @@ namespace pva.SuperV.EngineTests
             runnableProject = await Project.BuildAsync(wipProject);
             dynamic? instance = runnableProject.CreateInstance(ClassName, InstanceName);
             // WHEN
-            DateTime ts1 = DateTime.Parse("2025-03-01T00:00:00Z");
+            DateTime ts1 = ParseDateTime("2025-03-01T00:00:00Z");
             instance!.Value.SetValue(50, ts1, QualityLevel.Good);
             instance!.Value.SetValue(150, ts1.AddMinutes(15), QualityLevel.Good);
-            DateTime ts2 = DateTime.Parse("2025-03-01T01:00:00Z");
+            DateTime ts2 = ParseDateTime("2025-03-01T01:00:00Z");
             instance!.Value.SetValue(100, ts2, QualityLevel.Good);
 
             // THEN

--- a/pva.SuperV.Model/HistoryRetrieval/HistoryRowMapper.cs
+++ b/pva.SuperV.Model/HistoryRetrieval/HistoryRowMapper.cs
@@ -14,18 +14,18 @@ namespace pva.SuperV.Model.HistoryRetrieval
                     ))];
         }
 
+        public static List<HistoryStatisticsRowModel> ToDto(List<HistoryStatisticRow> rows, List<IFieldDefinition> fields)
+        {
+            return [.. rows.Select(row
+                => new HistoryStatisticsRowModel(row.Ts.ToUniversalTime(), row.StartTime, row.EndTime, row.Duration, row.Quality, BuildRowValues(row, fields, true)
+                    ))];
+        }
+
         public static List<HistoryRawRowModel> ToRawDto(List<HistoryRow> rows)
         {
             return [.. rows.Select(row
                 => new HistoryRawRowModel(row.Ts.ToUniversalTime(), row.Quality,
                        [.. row.Values.Select(value => value)]
-                    ))];
-        }
-
-        public static List<HistoryStatisticsRowModel> ToDto(List<HistoryStatisticRow> rows, List<IFieldDefinition> fields)
-        {
-            return [.. rows.Select(row
-                => new HistoryStatisticsRowModel(row.Ts.ToUniversalTime(), row.StartTime, row.EndTime, row.Duration, row.Quality, BuildRowValues(row, fields, true)
                     ))];
         }
 

--- a/pva.SuperV.TestsScenarios/Features/Project.feature
+++ b/pva.SuperV.TestsScenarios/Features/Project.feature
@@ -208,3 +208,5 @@ Scenario: Create project
 #		| StartTs              | EndTs                | Quality | Float,float,MAX | Int,int,MAX | Long,long,MAX | Short,short,MAX | String,string,MAX | TimeSpan,TimeSpan,MAX | Uint,uint,MAX | Ulong,ulong,MAX | Ushort,ushort,MAX | HistoryTrigger,int,MAX |
 #		| 2025-03-01T00:00:00Z | 2025-03-01T00:00:00Z | Good    | 3.21            | 134567      | 9876543       | 32767           | Hi from SuperV!   | 01:02:59              | 123456        | 98123456        | 32767             | 1                      |
 #		| 2025-03-01T00:59:59Z | 2025-03-01T00:00:00Z | Good    | 21.3            | 5654321     | 3456789       | -32767          | Bye from SuperV!  | 02:03:01              | 654321        | 654789          | 12768             | 1                      |
+
+	Then TDengine is stopped if running

--- a/pva.SuperV.TestsScenarios/StepDefinitions/BaseStepDefinition.cs
+++ b/pva.SuperV.TestsScenarios/StepDefinitions/BaseStepDefinition.cs
@@ -28,13 +28,12 @@ namespace pva.SuperV.TestsScenarios.StepDefinitions
                 "long" => new LongFieldValueModel(row.GetInt64(fieldCellName), formattedValue, qualityLevel, timestamp),
                 "short" => new ShortFieldValueModel(short.CreateChecked(row.GetInt32(fieldCellName)), formattedValue, qualityLevel, timestamp),
                 "string" => new StringFieldValueModel(row[fieldCellName], qualityLevel, timestamp),
-                "timespan" => new TimeSpanFieldValueModel(TimeSpan.Parse(row[fieldCellName]), formattedValue, qualityLevel, timestamp),
+                "timespan" => new TimeSpanFieldValueModel(ParseTimeSpan(row[fieldCellName]), formattedValue, qualityLevel, timestamp),
                 "uint" => new UintFieldValueModel(uint.CreateChecked(row.GetInt32(fieldCellName)), formattedValue, qualityLevel, timestamp),
                 "ulong" => new UlongFieldValueModel(ulong.CreateChecked(row.GetInt64(fieldCellName)), formattedValue, qualityLevel, timestamp),
                 "ushort" => new UshortFieldValueModel(ushort.CreateChecked(row.GetInt32(fieldCellName)), formattedValue, qualityLevel, timestamp),
                 _ => throw new NotImplementedException(),
             };
         }
-
     }
 }

--- a/pva.SuperV.TestsScenarios/StepDefinitions/ClassStepDefinitions.cs
+++ b/pva.SuperV.TestsScenarios/StepDefinitions/ClassStepDefinitions.cs
@@ -57,7 +57,7 @@ namespace pva.SuperV.TestsScenarios.StepDefinitions
                 "long" => new LongFieldDefinitionModel(fieldName, row.GetInt64("Default value"), format),
                 "short" => new ShortFieldDefinitionModel(fieldName, short.CreateChecked(row.GetInt32("Default value")), format),
                 "string" => new StringFieldDefinitionModel(fieldName, row["Default value"], format),
-                "timespan" => new TimeSpanFieldDefinitionModel(fieldName, TimeSpan.Parse(row["Default value"]), format),
+                "timespan" => new TimeSpanFieldDefinitionModel(fieldName, ParseTimeSpan(row["Default value"]), format),
                 "uint" => new UintFieldDefinitionModel(fieldName, uint.CreateChecked(row.GetInt32("Default value")), format),
                 "ulong" => new UlongFieldDefinitionModel(fieldName, ulong.CreateChecked(row.GetInt64("Default value")), format),
                 "ushort" => new UshortFieldDefinitionModel(fieldName, ushort.CreateChecked(row.GetInt32("Default value")), format),

--- a/pva.SuperV.TestsScenarios/StepDefinitions/FieldProcessingStepDefinitions.cs
+++ b/pva.SuperV.TestsScenarios/StepDefinitions/FieldProcessingStepDefinitions.cs
@@ -1,4 +1,5 @@
-﻿using pva.SuperV.Model.FieldProcessings;
+﻿using pva.SuperV.Engine.Exceptions;
+using pva.SuperV.Model.FieldProcessings;
 using Shouldly;
 using System.Net.Http.Json;
 
@@ -50,8 +51,9 @@ namespace pva.SuperV.TestsScenarios.StepDefinitions
 
         private static string GetFieldFromParameters(DataTableRow row, string columnName)
         {
-            return GetFieldFromParameters(row, columnName, true);
+            return GetFieldFromParameters(row, columnName, true) ?? throw new UnknownEntityException("Field", columnName);
         }
+
         private static string? GetFieldFromParameters(DataTableRow row, string columnName, bool mandatory)
         {
             string fieldValue = row[columnName];

--- a/pva.SuperV.TestsScenarios/StepDefinitions/InstanceStepDefinitions.cs
+++ b/pva.SuperV.TestsScenarios/StepDefinitions/InstanceStepDefinitions.cs
@@ -54,6 +54,7 @@ namespace pva.SuperV.TestsScenarios.StepDefinitions
 
                 response.StatusCode.ShouldBe(System.Net.HttpStatusCode.OK);
                 FieldModel? updatedField = await response.Content.ReadFromJsonAsync<FieldModel>();
+                updatedField.ShouldNotBeNull();
                 // Clear type as they are not exactly correct
                 updatedField = updatedField with { Type = "" };
                 // Set Timestamp with the one from retrieved value
@@ -88,7 +89,7 @@ namespace pva.SuperV.TestsScenarios.StepDefinitions
                 ? Enum.Parse<QualityLevel>(qualityString)
                 : QualityLevel.Good;
             DateTime? timestamp = row.TryGetValue("Timestamp", out string timestampString) && !String.IsNullOrEmpty(timestampString)
-                ? DateTime.Parse(timestampString).ToUniversalTime()
+                ? ParseDateTime(timestampString)
                 : null;
             return BuildFieldValueModel(row, "Value", fieldType, formattedValue, qualityLevel, timestamp);
         }

--- a/pva.SuperV.TestsScenarios/StepDefinitions/ProjectStepDefinitions.cs
+++ b/pva.SuperV.TestsScenarios/StepDefinitions/ProjectStepDefinitions.cs
@@ -38,5 +38,12 @@ namespace pva.SuperV.TestsScenarios.StepDefinitions
             ProjectModel? builtProject = await response.Content.ReadFromJsonAsync<ProjectModel>();
             builtProject.ShouldNotBeNull();
         }
+
+        [StepDefinition("TDengine is stopped if running")]
+        public async ValueTask ThenTDengineIsStoppedIfRunning()
+        {
+            _ = await StopTDengineContainerAsync().ConfigureAwait(false);
+        }
+
     }
 }

--- a/pva.SuperV.TestsScenarios/StepDefinitions/WebApplicationStepDefinitions.cs
+++ b/pva.SuperV.TestsScenarios/StepDefinitions/WebApplicationStepDefinitions.cs
@@ -1,22 +1,15 @@
 ﻿namespace pva.SuperV.TestsScenarios.StepDefinitions
 {
     [Binding]
-    public class WebApplicationStepDefinitions
+    public class WebApplicationStepDefinitions(ScenarioContext ScenarioContext)
     {
-        private readonly ScenarioContext scenarioContext;
-
-        public WebApplicationStepDefinitions(ScenarioContext scenarioContext)
-        {
-            this.scenarioContext = scenarioContext;
-        }
-
         [Given("REST application is started")]
         public void RestApplicationIsStarted()
         {
             TestProjectApplication testProjectApplication = new();
-            scenarioContext.Add(ScenarioContextExtensions.RestApplication, testProjectApplication);
+            ScenarioContext.Add(ScenarioContextExtensions.RestApplication, testProjectApplication);
             HttpClient client = testProjectApplication.CreateClient();
-            scenarioContext.Add(ScenarioContextExtensions.WebClient, client);
+            ScenarioContext.Add(ScenarioContextExtensions.WebClient, client);
         }
     }
 }


### PR DESCRIPTION
Unload all projects in order to close connection before stopping TDengine test container.

Fixed warnings.